### PR TITLE
Fix launch files for NAOqi 2.8.6

### DIFF
--- a/pepper_dcm_bringup/launch/pepper_bringup.launch
+++ b/pepper_dcm_bringup/launch/pepper_bringup.launch
@@ -4,7 +4,7 @@
   <arg name="robot_port"        default="$(optenv NAO_PORT 9559)" />
   <arg name="roscore_ip"        default="127.0.0.1" />
   <arg name="network_interface" default="eth0" />
-  <arg name="username"          default="" />
+  <arg name="user"              default="" />
   <arg name="password"          default="" />
 
  	<!-- Call Robot publisher -->
@@ -26,8 +26,8 @@
     <param name="motor_groups"        value="Head LArm RArm" /> <!-- either "Body" or separate groups in the order "Head LArm RArm" -->
     <param name="use_dcm"             value="false" />
     <param name="max_stiffness"       value="0.9" />
-    <param name="username"             value="$(arg username)" />
-    <param name="password"             value="$(arg password)" />
+    <param name="user"                value="$(arg user)" />
+    <param name="password"            value="$(arg password)" />
   </node>
-	
+
 </launch>

--- a/pepper_dcm_bringup/launch/pepper_bringup.launch
+++ b/pepper_dcm_bringup/launch/pepper_bringup.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="robot_ip"          default="$(optenv NAO_IP)" /> <!-- 127.0.0.1 -->
-  <arg name="robot_port"        default="$(optenv NAO_PORT 9559)" />
+  <arg name="robot_port"        default="$(optenv NAO_PORT)" />
   <arg name="roscore_ip"        default="127.0.0.1" />
   <arg name="network_interface" default="eth0" />
   <arg name="user"              default="" />

--- a/pepper_dcm_bringup/launch/pepper_dcm_bringup_position.launch
+++ b/pepper_dcm_bringup/launch/pepper_dcm_bringup_position.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="robot_ip"          default="$(optenv NAO_IP)" /> <!-- 127.0.0.1 -->
-  <arg name="robot_port"        default="$(optenv NAO_PORT 9559)" />
+  <arg name="robot_port"        default="$(optenv NAO_PORT)" />
   <arg name="roscore_ip"        default="127.0.0.1" />
   <arg name="network_interface" default="eth0" />
   <arg name="user"              default="" />

--- a/pepper_dcm_bringup/launch/pepper_dcm_bringup_position.launch
+++ b/pepper_dcm_bringup/launch/pepper_dcm_bringup_position.launch
@@ -4,6 +4,8 @@
   <arg name="robot_port"        default="$(optenv NAO_PORT 9559)" />
   <arg name="roscore_ip"        default="127.0.0.1" />
   <arg name="network_interface" default="eth0" />
+  <arg name="user"              default="" />
+  <arg name="password"          default="" />
 
   <!-- Call Robot publisher -->
   <include file="$(find pepper_description)/launch/pepper_upload.launch" />
@@ -19,6 +21,8 @@
     <param name="RobotPort"           value="$(arg robot_port)" />
     <param name="DriverBrokerIP"      value="$(arg roscore_ip)" />
     <param name="network_interface"   value="$(arg network_interface)" />
+    <param name="user"                value="$(arg user)" />
+    <param name="password"            value="$(arg password)" />
   </node>
-	
+
 </launch>


### PR DESCRIPTION
- user name parameter name was fixed to match other launch files
- remove forcing default port (the programs should be doing that, now)